### PR TITLE
docs: redaction dry-run, quiescence, and traces-found metric

### DIFF
--- a/docs/sources/tempo/operations/monitor/_index.md
+++ b/docs/sources/tempo/operations/monitor/_index.md
@@ -102,11 +102,12 @@ This dashboard is included in the Tempo repository for two reasons:
 
 > This is available as `tempo-backendwork.json`.
 
-The Backend Work dashboard monitors blocklist maintenance, compaction jobs, and backend component resources.
+The Backend Work dashboard monitors blocklist maintenance, compaction jobs, redaction activity, and backend component resources.
 It tracks blocklist length and poll duration, active and completed compaction jobs, failure and retry rates, and objects written and combined during compaction.
+It also includes per-tenant panels for traces matched by redaction jobs in apply mode and in dry-run mode (`tempo_backend_scheduler_redaction_traces_found_total`).
 The dashboard also shows CPU and memory usage for the backend-scheduler and backend-worker components.
 
-Use this dashboard to monitor compaction health, detect stalled or failing jobs, and right-size backend-scheduler and backend-worker resources.
+Use this dashboard to monitor compaction health, detect stalled or failing jobs, preview redaction blast radius from dry-runs, and right-size backend-scheduler and backend-worker resources.
 
 ### Tempo Block Builder dashboard
 

--- a/docs/sources/tempo/operations/tempo_cli.md
+++ b/docs/sources/tempo/operations/tempo_cli.md
@@ -966,12 +966,15 @@ tempo-cli rewrite-blocks drop-traces --drop-trace --backend=local --bucket=./cmd
 
 Remove traces containing personally identifiable information or other sensitive data from object storage without waiting for retention to expire.
 
-The `redact` command submits a redaction request to the [backend scheduler](/docs/tempo/<TEMPO_VERSION>/reference-tempo-architecture/components/compaction/#backend-scheduler). 
-The scheduler creates jobs that rewrite affected blocks in object storage to remove the specified traces. 
+The `redact` command submits a redaction request to the [backend scheduler](/docs/tempo/<TEMPO_VERSION>/reference-tempo-architecture/components/compaction/#backend-scheduler).
+The scheduler creates jobs that rewrite affected blocks in object storage to remove the specified traces.
 Unlike [`drop-traces`](#drop-traces-by-id), which operates directly on object storage from the CLI, `redact` delegates the work to the backend scheduler over gRPC.
 
+Provide exactly one selector: one or more `--trace-id` values, or a `--query` TraceQL selector.
+Use `--dry-run` to preview how many traces match without rewriting blocks.
+
 ```bash
-tempo-cli redact --tenant=<TENANT_ID> --trace-id=<TRACE_ID> [--trace-id=<TRACE_ID> ...] <scheduler-address>
+tempo-cli redact --tenant=<TENANT_ID> (--trace-id=<TRACE_ID> [--trace-id=<TRACE_ID> ...] | --query=<TRACEQL_QUERY>) [--dry-run] <scheduler-address>
 ```
 
 Arguments:
@@ -981,7 +984,9 @@ Arguments:
 Options:
 
 - `--tenant <value>` **(required)** Tenant ID.
-- `--trace-id <value>` **(required)** Trace ID to redact, in hex format. Specify multiple times to redact several traces in one request.
+- `--trace-id <value>` Trace ID to redact, in hex format. Specify multiple times to redact several traces in one request. Mutually exclusive with `--query`.
+- `--query <value>` TraceQL query that selects traces to redact. Mutually exclusive with `--trace-id`. The query must be a single spanset filter: `=` comparisons on `resource.*` or `span.*` attributes joined by `&&` or `||`. Regex, ordered comparisons, `parent.`-scoped attributes, pipelines, aggregates, and structural operators aren't supported.
+- `--dry-run` Evaluate the selector and report match counts without rewriting any blocks. Dry-run redaction doesn't disable tenant compaction or retention, enter quiescence, or arm a rescan. Refer to [Compaction](/docs/tempo/<TEMPO_VERSION>/reference-tempo-architecture/components/compaction/#redaction-apply-mode-versus-dry-run) for apply-mode lifecycle details.
 - `--tls` Use TLS for the gRPC connection (default: `false`).
 - `--tls-server-name <value>` Override the TLS server name (SNI).
 - `--tls-ca <value>` Path to a PEM-encoded CA certificate file.
@@ -993,7 +998,10 @@ batch_id:     <BATCH_ID>
 jobs_created: <COUNT>
 ```
 
+When you use `--dry-run`, the output also includes a `mode: dry-run` line indicating that jobs report match counts without rewriting blocks.
+
 Monitor job progress through the [`/status/backendscheduler`](/docs/tempo/<TEMPO_VERSION>/api_docs/#backend-scheduler-job-status) endpoint.
+Track per-tenant match counts with `tempo_backend_scheduler_redaction_traces_found_total` (`mode=apply` or `mode=dry_run`).
 
 ### Examples
 
@@ -1007,6 +1015,18 @@ Redact multiple traces in one request:
 
 ```bash
 tempo-cli redact --tenant=my-tenant --trace-id=931281e2a09876de16e15f45ff86283d --trace-id=00000000000000000000000000000001 localhost:9095
+```
+
+Redact traces matching a TraceQL query:
+
+```bash
+tempo-cli redact --tenant=my-tenant --query='{ resource.service.name = "payments" && span.http.status_code = 500 }' localhost:9095
+```
+
+Preview matches with dry-run (no blocks rewritten):
+
+```bash
+tempo-cli redact --tenant=my-tenant --query='{ resource.service.name = "payments" }' --dry-run localhost:9095
 ```
 
 With TLS and a custom CA:

--- a/docs/sources/tempo/reference-tempo-architecture/components/compaction.md
+++ b/docs/sources/tempo/reference-tempo-architecture/components/compaction.md
@@ -4,7 +4,7 @@ menuTitle: Compaction
 description: How the backend scheduler and worker handle compaction and retention.
 weight: 700
 topicType: concept
-versionDate: 2026-03-20
+versionDate: 2026-08-07
 ---
 
 # Compaction
@@ -39,6 +39,22 @@ When a worker calls `Next`, the scheduler assigns an available job and persists 
 The worker executes the job and calls `UpdateJob` with a success or failure status.
 On success, the scheduler applies the results to the in-memory blocklist (for example, marking compacted blocks as removed).
 The work cache is periodically flushed to object storage for crash recovery.
+
+#### Redaction apply mode versus dry-run
+
+Redaction requests run in **apply** mode by default, or in **dry-run** mode when you submit with `tempo-cli redact --dry-run`.
+
+Apply-mode redaction is exclusive for the tenant:
+
+- While an apply batch is active, the scheduler disables compaction and retention for that tenant.
+- When all apply-mode redaction jobs finish (and any pending rescan completes), the batch enters a short **quiescence** window instead of being removed immediately.
+- During quiescence, compaction stays disabled so a rescan can cover blocks that compaction produced just as the last redaction job finished.
+- The quiescence deadline is `2 × backend_scheduler.maintenance_interval` (the default `maintenance_interval` is `1m`).
+- After the deadline, the scheduler removes the batch and re-enables compaction and retention.
+
+Dry-run redaction evaluates the selector and reports match counts without rewriting blocks.
+A dry-run batch still occupies the tenant's one-batch slot (a second submission is rejected while it is active), but it doesn't disable compaction or retention, enter quiescence, or arm a rescan.
+When its jobs finish, the scheduler removes the dry-run batch immediately.
 
 ## Backend scheduler
 
@@ -108,12 +124,14 @@ This endpoint is useful for diagnosing stalled jobs, verifying that workers are 
 | `tempo_backend_scheduler_jobs_failed_total` | Jobs that failed |
 | `tempo_backend_scheduler_jobs_active` | Jobs currently assigned to a worker |
 | `tempo_backend_scheduler_job_duration_seconds` | Job execution duration histogram |
+| `tempo_backend_scheduler_redaction_traces_found_total` | Traces matched by redaction jobs, labeled by `tenant` and `mode` (`apply` counts traces actually removed; `dry_run` counts the previewed match set with nothing removed) |
 | `tempodb_blocklist_length` | Number of live blocks per tenant; high values indicate compaction is falling behind |
 | `tempodb_compaction_outstanding_blocks` | Outstanding blocks awaiting compaction per tenant; the primary autoscaling signal |
 
 Most scheduler job metrics carry `tenant` and `job_type` labels; `tempo_backend_scheduler_job_duration_seconds` carries only `job_type`.
 The `job_type` label uses protobuf enum string values: `JOB_TYPE_COMPACTION`, `JOB_TYPE_RETENTION`, and `JOB_TYPE_REDACTION`.
 The duration histogram measures elapsed time from job creation to completion, not execution time alone.
+Zero-match redaction jobs don't increment `tempo_backend_scheduler_redaction_traces_found_total`.
 
 ## Monitoring
 
@@ -123,6 +141,7 @@ The Tempo mixin ships a pre-built Grafana dashboard, **Tempo - Backend Work**, t
 - Active, completed, failed, and retried job counts
 - Compaction throughput (objects written, bytes written, blocks compacted)
 - Outstanding blocks per tenant
+- Per-tenant redaction traces found for apply mode and dry-run mode (`tempo_backend_scheduler_redaction_traces_found_total`)
 - CPU and memory for both the backend scheduler and backend workers
 - A backend-worker autoscaling panel
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
> This PR was drafted by the docs-workforce automation (AI-assisted). Technical review required: verify every claim against the code before merging. Sources are linked inline.

Closes #47

<!-- docs-workforce:knylander-grafana/tempo-doc-work:7d -->
run: dw-2026-08-07-b945f498

## Summary

Documents backend-scheduler redaction gaps from the weekly Tempo docs sweep (merged since 2026-07-31):

| Upstream PR | What was documented | Files |
|-------------|---------------------|-------|
| [grafana/tempo#7700](https://github.com/grafana/tempo/pull/7700) | Dry-run does not block compaction/retention, quiesce, or arm rescan; CLI `--dry-run` | `tempo_cli.md`, `compaction.md` |
| [grafana/tempo#7695](https://github.com/grafana/tempo/pull/7695) | Apply-mode quiescence window (`2 × maintenance_interval`) | `compaction.md` |
| [grafana/tempo#7699](https://github.com/grafana/tempo/pull/7699) | `tempo_backend_scheduler_redaction_traces_found_total{tenant,mode}` + Backend Work panels | `compaction.md`, `monitor/_index.md` |

Also documents CLI `--query` (TraceQL selector) on the Redact traces page because it is required to use dry-run meaningfully and was still missing on `main` (adjacent to [grafana/tempo#7663](https://github.com/grafana/tempo/pull/7663); may overlap open PR #39).

## Files changed

- `docs/sources/tempo/operations/tempo_cli.md`
- `docs/sources/tempo/reference-tempo-architecture/components/compaction.md`
- `docs/sources/tempo/operations/monitor/_index.md`

## Review notes

- Claims verified against grafana/tempo `main` code (`quiescenceSweeps = 2`, `maintenance_interval` default `1m`, metric name/labels, CLI flags).
- `make vale` / `doc-validator` unavailable in this environment (Docker/`errr` missing); manual style, frontmatter, link, and sensitive-data review completed.
- No screenshot inventory for this window.
- Do not merge without human technical review.

## Unknowns

- Issue #47 body could not be updated (GraphQL: Resource not accessible by integration); existing open issue with the same workforce marker was reused.
- Possible overlap with open PR #39 on `tempo_cli.md` Redact traces (`--query` / `--dry-run` flags).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-782496cd-738a-43d0-8d2b-e575d2281726?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-782496cd-738a-43d0-8d2b-e575d2281726&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

